### PR TITLE
Set type attribute for byte-compile warnings

### DIFF
--- a/meson-mode.el
+++ b/meson-mode.el
@@ -316,7 +316,8 @@ and LIMIT is used to limit the scan."
   :prefix "meson-")
 
 (defcustom meson-indent-basic 2
-  "Indentation offset for meson.build files.")
+  "Indentation offset for meson.build files."
+  :type 'integer)
 
 (defun meson-smie-rules (kind token)
 ;;   (ignore-errors


### PR DESCRIPTION
Newer Emacs says warnings for `defcustom` variable which does not have `:type` attribute as below.

```
meson-mode.el:318:1:Warning: defcustom for ‘meson-indent-basic’ fails to
    specify type
meson-mode.el:318:1:Warning: defcustom for ‘meson-indent-basic’ fails to
    specify type
```