### PR TITLE
Also use meson-mode automatically for "meson_options.txt"

### DIFF
--- a/meson-mode.el
+++ b/meson-mode.el
@@ -745,7 +745,7 @@ comments."
 
 ;;;###autoload
 (progn
-  (add-to-list 'auto-mode-alist '("/meson\\.build\\'" . meson-mode))
+  (add-to-list 'auto-mode-alist '("/meson\\(\\.build\\|_options\\.txt\\)\\'" . meson-mode))
   (eval-after-load 'compile
     '(progn
        (add-to-list 'compilation-error-regexp-alist 'meson)


### PR DESCRIPTION
The syntax of the options file is a subset of meson.build. Using the
same rules gives nice syntax highlighting and indentation for free.