### PR TITLE
Fix compilation warnings

### DIFF
--- a/meson-mode.el
+++ b/meson-mode.el
@@ -35,6 +35,8 @@
 
 ;;; Code:
 
+(require 'compile)
+
 (defvar meson-mode-syntax-table
   (let ((table (make-syntax-table))
 	(list (list ?\# "<"

--- a/meson-mode.el
+++ b/meson-mode.el
@@ -478,17 +478,16 @@ and LIMIT is used to limit the scan."
        ;; kwargs
        ((and (> (nth 0 ppss) 0)		; inside parentheses
 	     (eq (char-after (nth 1 ppss)) ?\()) ; rounded parentheses
-	(save-excursion
-	  (goto-char (nth 1 ppss))
-	  (let ((kwargs (cl-some (lambda (x)
-				   (when (looking-back (concat (car x) (rx (zero-or-more (any " " "\t"))))
-						       (line-beginning-position))
-				     (cdr x)))
-				 meson-kwargs)))
-	    ;; complete mathing kwargs as well as built-in
-	    ;; variables/functions
-	    (list start end (append kwargs meson-builtin-vars
-				    meson-builtin-functions)))))
+	(goto-char (nth 1 ppss))
+	(let ((kwargs (cl-some (lambda (x)
+				 (when (looking-back (concat (car x) (rx (zero-or-more (any " " "\t"))))
+						     (line-beginning-position))
+				   (cdr x)))
+			       meson-kwargs)))
+	  ;; complete mathing kwargs as well as built-in
+	  ;; variables/functions
+	  (list start end (append kwargs meson-builtin-vars
+				  meson-builtin-functions))))
 
        ;; methods
        ((eq (char-before) ?.)


### PR DESCRIPTION
Fixes:

```
meson-mode.el:757:22:Warning: reference to free variable
    ‘compilation-error-regexp-alist’
meson-mode.el:759:23:Warning: assignment to free variable
    ‘compilation-error-regexp-alist’
meson-mode.el:758:22:Warning: reference to free variable
    ‘compilation-error-regexp-alist-alist’
meson-mode.el:758:22:Warning: assignment to free variable
    ‘compilation-error-regexp-alist-alist’
```