### PR TITLE
meson-mode: fix completion

### DIFF
--- a/meson-mode.el
+++ b/meson-mode.el
@@ -99,7 +99,7 @@
       (zero-or-more whitespace)
       (or "(" line-end)))
 
-(eval-when-compile
+(eval-and-compile
   (defconst meson-builtin-vars
     '("meson" "build_machine" "host_machine" "target_machine")))
 


### PR DESCRIPTION
Otherwise, when running meson-completion-at-point-function the warning
is printed:

Company: An error occurred in auto-begin
Company: backend company-capf error "Symbol’s value as variable is void: meson-builtin-vars" with args (prefix)