### PR TITLE
meson-lookup-doc: Don't preserve window pos

### DIFF
--- a/meson-mode.el
+++ b/meson-mode.el
@@ -933,7 +933,8 @@ or does not contain IDENTIFIER."
                          (user-error "No identifier at point"))))
   (let ((buf (find-file-noselect
               (or (meson--find-reference-manual)
-                  (user-error "Meson reference manual not found")))))
+                  (user-error "Meson reference manual not found"))))
+	(switch-to-buffer-preserve-window-point nil))
     (with-current-buffer buf
       ;; Set up buffer only once after creation.
       (unless (string= (buffer-name) "*Meson Reference Manual*")


### PR DESCRIPTION
This fixes the issue that you can only lookup once in the manual (when
the buffer is not yet assigned with an existing window)