### PR TITLE
Use lexical binding in `utils.el`

### DIFF
--- a/utils.el
+++ b/utils.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t; -*-
 (defun py2el (beg end)
   "Helper function for converting Meson data structures from
 Python sources to something more similar to elisp."

--- a/utils.el
+++ b/utils.el
@@ -1,4 +1,3 @@
-
 (defun py2el (beg end)
   "Helper function for converting Meson data structures from
 Python sources to something more similar to elisp."
@@ -35,6 +34,6 @@ Run this in a buffer with meson/docs/markdown/Reference-manual.md"
 			      (skip-syntax-forward " ")
 			      (buffer-substring-no-properties (point) (line-end-position))))))
 	    ;;(edebug)
-	    (add-to-list 'functions (list funcname :doc synopsis)
+	    (push (list funcname :doc synopsis) functions
 	     )))
 	(kill-new (prin1-to-string (reverse functions)))))))


### PR DESCRIPTION
Upstream Emacs has enabled warnings for `.el` files with no lexical-binding directive, so this file triggers a:

    In toplevel form:
    utils.el:1:1: Warning: file has no ‘lexical-binding’ directive on its first line

Fix that.
