### PR TITLE
meson-mode.el: fix "undeclared function evil-local-set-key" warning

### DIFF
--- a/meson-mode.el
+++ b/meson-mode.el
@@ -955,6 +955,7 @@ or does not contain IDENTIFIER."
           (markdown-view-mode))
         (local-set-key (kbd "q") 'bury-buffer)
         (when (bound-and-true-p evil-mode)
+          (declare-function evil-local-set-key nil) ;; suppress "undeclared" warning
           (evil-local-set-key 'normal (kbd "q") 'bury-buffer)))
       (let* ((position
 	      (or (meson--search-in-reference-manual identifier)


### PR DESCRIPTION
This should be the last warning that was present in meson-mode

Fixes a warning:

    In end of data:
    meson-mode.el:958:12: Warning: the function ‘evil-local-set-key’ is not known to be defined.
