### PR TITLE
Add `meson.options` to auto-mode-alist

### DIFF
--- a/meson-mode.el
+++ b/meson-mode.el
@@ -1001,7 +1001,9 @@ or does not contain IDENTIFIER."
 
 ;;;###autoload
 (progn
-  (add-to-list 'auto-mode-alist '("/meson\\(\\.build\\|_options\\.txt\\)\\'" . meson-mode))
+  (add-to-list
+   'auto-mode-alist
+   '("/meson\\(\\.build\\|_options\\.txt\\|\\.options\\)\\'" . meson-mode))
   (eval-after-load 'compile
     '(progn
        (add-to-list 'compilation-error-regexp-alist 'meson)


### PR DESCRIPTION
`meson.options` has been supported since version 1.1 of Meson (and seems to be preferred over `meson_options.txt`, according to the official documentation).